### PR TITLE
PHP8 fix with parse_str missing second param

### DIFF
--- a/core/components/imageslim/elements/snippets/imageslim.snippet.php
+++ b/core/components/imageslim/elements/snippets/imageslim.snippet.php
@@ -49,7 +49,8 @@
 if (empty($input)) { return; }  // if we've got nothing to do, it's quittin' time
 
 if (isset($options)) {  // if we're being called as an output filter, set variables for any options
-	parse_str($options);
+	parse_str($options, $arrout);
+	return $arrout;
 }
 
 // process our properties


### PR DESCRIPTION
PHP requires the second parameter for `parse_str()`.